### PR TITLE
fix: Add real-time streaming output support for progress monitoring (#1)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,10 @@ inputs:
     description: "Optional path to a custom Bun executable. If provided, skips automatic Bun installation and uses this executable instead. WARNING: Using an incompatible version may cause problems if the action requires specific Bun features. This input is typically not needed unless you're debugging something specific or have unique needs in your environment."
     required: false
     default: ""
+  stream_output_file:
+    description: "Path to write streaming JSON Lines output for real-time monitoring. If not provided, streaming output is disabled."
+    required: false
+    default: ""
 
 outputs:
   execution_file:
@@ -213,6 +217,7 @@ runs:
         INPUT_ACTION_INPUTS_PRESENT: ${{ steps.prepare.outputs.action_inputs_present }}
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        INPUT_STREAM_OUTPUT_FILE: ${{ inputs.stream_output_file }}
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -10,6 +10,7 @@ const execAsync = promisify(exec);
 
 const PIPE_PATH = `${process.env.RUNNER_TEMP}/claude_prompt_pipe`;
 const EXECUTION_FILE = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
+const STREAM_OUTPUT_FILE = process.env.INPUT_STREAM_OUTPUT_FILE || "";
 const BASE_ARGS = ["--verbose", "--output-format", "stream-json"];
 
 export type ClaudeOptions = {
@@ -138,10 +139,32 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
     pipeStream.destroy();
   });
 
+  // Only create stream writer if output file is specified
+  let streamWriter: ReturnType<typeof createWriteStream> | null = null;
+
+  if (STREAM_OUTPUT_FILE && STREAM_OUTPUT_FILE.trim() !== "") {
+    try {
+      streamWriter = createWriteStream(STREAM_OUTPUT_FILE, { flags: "a" });
+      console.log(`Streaming output enabled: ${STREAM_OUTPUT_FILE}`);
+
+      streamWriter.on("error", (error) => {
+        core.warning(`Failed to write to stream output file: ${error}`);
+        streamWriter = null; // Disable on error
+      });
+    } catch (error) {
+      core.warning(`Could not create stream output file: ${error}`);
+    }
+  }
+
   // Capture output for parsing execution metrics
   let output = "";
   claudeProcess.stdout.on("data", (data) => {
     const text = data.toString();
+
+    // Write to stream file if enabled
+    if (streamWriter) {
+      streamWriter.write(text);
+    }
 
     // Try to parse as JSON and pretty print if it's on a single line
     const lines = text.split("\n");
@@ -205,6 +228,11 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
     pipeProcess.kill("SIGTERM");
   } catch (e) {
     // Process may already be dead
+  }
+
+  // Close the stream writer if it exists
+  if (streamWriter) {
+    streamWriter.end();
   }
 
   // Clean up pipe file


### PR DESCRIPTION
This commit implements the streaming output feature as specified in issue #1.

Changes:
- Added optional `stream_output_file` input parameter to action.yml
- Modified base-action/src/run-claude.ts to conditionally create a WriteStream
- Stream writes Claude's JSON output in real-time when enabled
- Graceful error handling and cleanup on stream writer
- Zero overhead when disabled (default behavior)
- Fully backward compatible

The feature enables external tools to monitor Claude's progress in real-time by watching the streaming JSON Lines output file as Claude executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)